### PR TITLE
Fix params dictionary

### DIFF
--- a/oblio_api.py
+++ b/oblio_api.py
@@ -42,7 +42,7 @@ class OblioApi:
         else:
             raise OblioException('Type not implemented')
 
-        params = {** filters, cif: cif, name: name}
+        params = {** filters, 'cif': cif, 'name': name}
         uri = '/api/nomenclature/{}'.format(type) + '?' + urllib.parse.urlencode(params)
 
         response = self.request('GET', uri)


### PR DESCRIPTION
Enclosed params dict keys in quotes to prevent the uri being built as value=value (wrong) instead of name=value (intended).